### PR TITLE
fix: check hash of mentor file

### DIFF
--- a/localmentor/utils.py
+++ b/localmentor/utils.py
@@ -1,24 +1,53 @@
+import hashlib
 import os
+import sys
 import requests
+
+def calculate_sha1(filepath):
+    sha1 = hashlib.sha1()
+    with open(filepath, 'rb') as f:
+        while True:
+            data = f.read(8192)
+            if not data:
+                break
+            sha1.update(data)
+    return sha1.hexdigest()
 
 def download_mentor():
     bin_dir = os.path.join(os.path.dirname(__file__), 'bin')
     mentor_path = os.path.join(bin_dir, 'mentor')
 
+    # Expected SHA1 hash of the remote mentor file
+    expected_hash = "6dfab6acf5c33e89e52492f1865eb57d84667e77"
+
     # Create the 'bin/' directory if it does not exist
     if not os.path.exists(bin_dir):
         os.makedirs(bin_dir, exist_ok=True)
 
-    # Download mentor file if it does not exist
-    if not os.path.exists(mentor_path):
-        print("Downloading mentor...")
-        model_url = "https://remyx.ai/assets/localmentor/0.0.1/mentor"
-        response = requests.get(model_url, stream=True)
-        with open(mentor_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
+    # Check if the file exists and its hash
+    if os.path.exists(mentor_path):
+        local_hash = calculate_sha1(mentor_path)
+        if local_hash == expected_hash:
+            return
+        else:
+            print("Unexpected mentor found. Redownloading...")
 
-        # Make the file executable
-        os.chmod(mentor_path, 0o755)
+    model_url = "https://remyx.ai/assets/localmentor/0.0.1/mentor"
+    response = requests.get(model_url, stream=True)
 
-        print("Download complete.")
+    total_size = int(response.headers.get('content-length', 0))
+    chunk_size = 8192
+    downloaded = 0
+
+    with open(mentor_path, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+            f.write(chunk)
+            downloaded += len(chunk)
+            percentage = 100 * downloaded // total_size
+            sys.stdout.write(f'\rDownloading mentor... {percentage}%')
+            sys.stdout.flush()
+
+    # Make the file executable
+    os.chmod(mentor_path, 0o755)
+
+    print("\nDownload complete.")


### PR DESCRIPTION
When downloading the mentor I accidentally closed my terminal which resulted in an incomplete mentor file. Running the command again just produced an empty string.

This change does a check when 'download_mentor' is called to determine if the local file matches the remote file, and if there is a mismatch the mentor is redownloaded.

The remote hash is hardcoded.

Alternatively, ranges could be used to resume the HTTP request but I'm unsure if the remote server supports it. Or a .hash file could be generated and its existence could indicate if the mentor is fully downloaded, but those are just some options. 